### PR TITLE
Raise engines node version to >= 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/iobroker-community-adapters/ioBroker.plex/issues"
   },
   "engines": {
-    "node": ">= 18"
+  "node": ">= 20"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.3.2",


### PR DESCRIPTION

**Beschreibung:**
Die engines-Klausel in der package.json wurde von `>= 18` auf `>= 20` angehoben, da die Tests für Node.js 20, 22 und 24 konfiguriert sind. Damit wird sichergestellt, dass die unterstützten Node.js-Versionen mit den getesteten Versionen übereinstimmen.

-